### PR TITLE
hash comparison

### DIFF
--- a/src/Hautelook/Phpass/PasswordHash.php
+++ b/src/Hautelook/Phpass/PasswordHash.php
@@ -309,6 +309,6 @@ class PasswordHash
             $hash = crypt($password, $stored_hash);
         }
 
-        return $hash == $stored_hash;
+        return $hash === $stored_hash;
     }
 }


### PR DESCRIPTION
Following http://blog.whitehatsec.com/magic-hashes/ hashes need to be compared with ===