### PR TITLE
Use `hash_equals` to prevent timing attacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
+sudo: false
+
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.6.0"
     },
     "autoload": {
         "psr-0": {"Hautelook": "src/"}

--- a/src/Hautelook/Phpass/PasswordHash.php
+++ b/src/Hautelook/Phpass/PasswordHash.php
@@ -6,7 +6,12 @@ namespace Hautelook\Phpass;
  *
  * Portable PHP password hashing framework.
  *
- * Version 0.3 / genuine.
+ * Version 0.4-nrhl / modified by Nordstromrack.com | HauteLook
+ *
+ * Change Log:
+ *
+ * - the hash_equals function is now used instead of == or === to prevent
+ *   timing attacks
  *
  * Written by Solar Designer <solar at openwall.com> in 2004-2006 and placed in
  *
@@ -309,6 +314,6 @@ class PasswordHash
             $hash = crypt($password, $stored_hash);
         }
 
-        return $hash === $stored_hash;
+        return hash_equals($stored_hash, $hash);
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: This will break anyone using < PHP 5.6