### PR TITLE
Do hash_equals if possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 language: php
 
 php:
+  - 5.3
+  - 5.4
+  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0"
+        "php": ">=5.3.3"
     },
     "autoload": {
         "psr-0": {"Hautelook": "src/"}

--- a/src/Hautelook/Phpass/PasswordHash.php
+++ b/src/Hautelook/Phpass/PasswordHash.php
@@ -313,7 +313,11 @@ class PasswordHash
         if ($hash[0] == '*') {
             $hash = crypt($password, $stored_hash);
         }
-
-        return hash_equals($stored_hash, $hash);
+        
+        if (function_exists('hash_equals')) {
+            return hash_equals($stored_hash, $hash);
+        } else {
+            return $hash === $stored_hash;
+        }
     }
 }


### PR DESCRIPTION
This latest commit kind of screwed up my app which is still on PHP 5.5. I suggest using hash_equals if on 5.6, but let's not leave behind PHP versions that can't support it. I recommend checking with function_exists to see if hash_equals is available.