### PR TITLE
Suggestion: Polyfill PHP features when able

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 language: php
 
 php:
+  - 5.3
+  - 5.4
+  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0"
+        "php": ">=5.3.3",
+        "paragonie/random_compat": "~1.0",
+        "symfony/polyfill-php56": "~1.0"
     },
     "autoload": {
         "psr-0": {"Hautelook": "src/"}

--- a/src/Hautelook/Phpass/PasswordHash.php
+++ b/src/Hautelook/Phpass/PasswordHash.php
@@ -70,25 +70,7 @@ class PasswordHash
      */
     public function get_random_bytes($count)
     {
-        $output = '';
-        if (@is_readable('/dev/urandom') &&
-            ($fh = @fopen('/dev/urandom', 'rb'))) {
-            $output = fread($fh, $count);
-            fclose($fh);
-        }
-
-        if (strlen($output) < $count) {
-            $output = '';
-            for ($i = 0; $i < $count; $i += 16) {
-                $this->random_state =
-                    md5(microtime() . $this->random_state);
-                $output .=
-                    pack('H*', md5($this->random_state));
-            }
-            $output = substr($output, 0, $count);
-        }
-
-        return $output;
+        return random_bytes($count);
     }
 
     /**


### PR DESCRIPTION
This is purely a suggestion and if accepted would restore older PHP version support.

First, the [paragonie/random_compat](https://github.com/paragonie/random_compat) polyfill for PHP 7's `random_bytes()` function replaces the contents of the `PasswordHash::get_random_bytes()` method.

Second, Symfony's [PHP 5.6 polyfill](https://github.com/symfony/polyfill-php56/blob/v1.1.0/Php56.php#L24) is added to make use of `hash_equals()`.