### PR TITLE
Use PHP7 `random_bytes` function if available.

### DIFF
--- a/src/Hautelook/Phpass/PasswordHash.php
+++ b/src/Hautelook/Phpass/PasswordHash.php
@@ -71,6 +71,11 @@ class PasswordHash
     public function get_random_bytes($count)
     {
         $output = '';
+        
+        if (is_callable('random_bytes')) {
+            return random_bytes($count);
+        }
+        
         if (@is_readable('/dev/urandom') &&
             ($fh = @fopen('/dev/urandom', 'rb'))) {
             $output = fread($fh, $count);


### PR DESCRIPTION
This change adds an early return to `PasswordHash->get_random_bytes()` that defers random byte resolution to the core PHP `random_bytes` function if available. This allows us to easily beef up our random byte generation in all environments.