### PR TITLE
Forward compatibility of tests with latest PHPunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 before_script:

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -12,3 +12,12 @@ if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php'))) {
         'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
         'php composer.phar install'.PHP_EOL);
 }
+
+// PHPUnit 6 compatibility for previous versions
+if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner\Version::id(), '6.0', '>=' ) ) {
+    class_alias( 'PHPUnit\Framework\Assert',        'PHPUnit_Framework_Assert' );
+    class_alias( 'PHPUnit\Framework\TestCase',      'PHPUnit_Framework_TestCase' );
+    class_alias( 'PHPUnit\Framework\Error\Error',   'PHPUnit_Framework_Error' );
+    class_alias( 'PHPUnit\Framework\Error\Notice',  'PHPUnit_Framework_Error_Notice' );
+    class_alias( 'PHPUnit\Framework\Error\Warning', 'PHPUnit_Framework_Error_Warning' );
+}


### PR DESCRIPTION
All tests now fail under PHP 7 because latest PHPUnit isn't backward compatible with previous versions (short story: all classes like `PHPUnit_Framework_TestCase` are now namespaced like `PHPUnit\Framework\TestCase`). See for example: https://travis-ci.org/ozh/phpass/jobs/224013803#L157

In order to keep a library compatible with various version of PHP - as opposed as supporting only PHP 7+ - there are (to my knowledge at least) 2 solutions:
- either force use of a prior version of PHPUnit (ie run PHP 7 tests with PHPUnit 5.7 instead of 6)
- or introduce a compatibility shim for namespace compatibility

I picked the second solution, which is better in my opinion because it will allow use of latest PHPunit.

