### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
-sudo: false
-
 language: php
 
 php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - 7.2
+  - 7.3
 
 before_script:
     - composer install
 
-script: cd Tests && phpunit --configuration phpunit.xml --coverage-text
+script: vendor/bin/phpunit --configuration Tests/phpunit.xml --coverage-text

--- a/Tests/BasicTest.php
+++ b/Tests/BasicTest.php
@@ -1,11 +1,11 @@
 <?php
 
-// namespace Hautelook\Phpass\Tests;
+namespace Hautelook\Phpass\Tests;
 
 use Hautelook\Phpass\PasswordHash;
 
 /**
- * 
+ *
  */
 class BasicTest extends \PHPUnit_Framework_TestCase
 {
@@ -15,7 +15,7 @@ class BasicTest extends \PHPUnit_Framework_TestCase
     	$hasher  = new PasswordHash(8,false);
     	$correct = 'test12345';
 		$hash 	 = $hasher->HashPassword($correct);
-		
+
 		$this->assertTrue($hasher->CheckPassword($correct, $hash));
     }
 

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -12,12 +12,3 @@ if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php'))) {
         'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
         'php composer.phar install'.PHP_EOL);
 }
-
-// PHPUnit 6 compatibility for previous versions
-if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner\Version::id(), '6.0', '>=' ) ) {
-    class_alias( 'PHPUnit\Framework\Assert',        'PHPUnit_Framework_Assert' );
-    class_alias( 'PHPUnit\Framework\TestCase',      'PHPUnit_Framework_TestCase' );
-    class_alias( 'PHPUnit\Framework\Error\Error',   'PHPUnit_Framework_Error' );
-    class_alias( 'PHPUnit\Framework\Error\Notice',  'PHPUnit_Framework_Error_Notice' );
-    class_alias( 'PHPUnit\Framework\Error\Warning', 'PHPUnit_Framework_Error_Warning' );
-}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,13 @@
     "require": {
         "php": ">=5.6.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^5"
+    },
     "autoload": {
-        "psr-0": {"Hautelook": "src/"}
+        "psr-4": {"Hautelook\\Phpass\\": "src/Hautelook/Phpass/"}
+    },
+    "autoload-dev": {
+        "psr-4": {"Hautelook\\Phpass\\Tests\\": "src/Hautelook/Phpass/"}
     }
 }

--- a/src/Hautelook/Phpass/PasswordHash.php
+++ b/src/Hautelook/Phpass/PasswordHash.php
@@ -71,11 +71,11 @@ class PasswordHash
     public function get_random_bytes($count)
     {
         $output = '';
-        
+
         if (is_callable('random_bytes')) {
             return random_bytes($count);
         }
-        
+
         if (@is_readable('/dev/urandom') &&
             ($fh = @fopen('/dev/urandom', 'rb'))) {
             $output = fread($fh, $count);


### PR DESCRIPTION
# Changed log
- Remove additional white spaces.
- Using the namespace for test classes.
- To avoid PHPUnit version pre-built in Travis CI build is not correct, using the `vendor/bin/phpunit` instead.
Define the PHPUnit version inside `require-dev` block in `composer.json` to let developers install development environment easily.